### PR TITLE
カレンダーの表示、予定のUTC表示の削除

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -37,7 +37,24 @@ $(function () {
     $(document).on('turbolinks:before-cache', clearCalendar);
 
     $('#calendar').fullCalendar({
-    events: '/events.json'
+    events: '/events.json',
+    titleFormat: 'YYYY年 M月',
+    dayNamesShort: ['日', '月', '火', '水', '木', '金', '土'],
+    header: {
+                    left: 'today',
+                    center: 'title',
+                    right: 'prevYear,prev,next,nextYear'
+                },
+    buttonText: {
+                    prev: '前',
+                    next: '次',
+                    prevYear: '前年',
+                    nextYear: '翌年',
+                    today: '今日',
+                },
+    eventColor: '#63ceef',
+    eventTextColor: '#000000',
+    timeFormat: "HH:mm",
     });
 }
 });

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -17,8 +17,8 @@
         <% @events.each do |event| %>
           <tr>
             <td class ="event_tbody"><%= event.title %></td>
-            <td class ="event_tbody"><%= event.start %></td>
-            <td class ="event_tbody"><%= event.end %></td>
+            <td class ="event_tbody"><%= event.start.strftime("%Y-%m-%d %H:%M:%S") %></td>
+            <td class ="event_tbody"><%= event.end.strftime("%Y-%m-%d %H:%M:%S") %></td>
             <td><%= link_to '詳細を見る', event,class: "btn btn-primary btn-lg active" %></td>
             <td><%= link_to '編集する', edit_event_path(event),class: "btn btn-primary btn-lg active" %></td>
             <td><%= link_to '削除する', event, method: :delete, data: { confirm: '本当に削除しますか？' },class: "btn btn-danger btn-lg active" %></td>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -14,12 +14,12 @@
 
     <p class="events-show">
       <strong>開始予定:</strong><br><br><br>
-      <%= @event.start %>
+      <%= @event.start.strftime("%Y-%m-%d %H:%M:%S") %>
     </p><br><br>
 
     <p class="events-show">
       <strong>終了予定:</strong><br><br><br>
-      <%= @event.end %>
+      <%= @event.end.strftime("%Y-%m-%d %H:%M:%S") %>
     </p><br><br>
     
     <div class="row">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,13 +31,13 @@
             <br>
             <ul class="nav navbar-nav navbar-right">
               <% if user_signed_in? %>       
-                <li><%= link_to 'マイページ', user_path(current_user.id), class: 'glyphicon glyphicon-home home' %></li>
-                <li><%= link_to 'スケジュール', event_user_path(current_user.id), class: 'glyphicon glyphicon-home home' %></li>
-                <li><%= link_to '日記投稿', new_diary_path(current_user.id), class: 'glyphicon glyphicon-user users' %></li>
+                <li><%= link_to 'マイページ', user_path(current_user.id), class: 'glyphicon glyphicon-user users' %></li>
+                <li><%= link_to 'スケジュール', event_user_path(current_user.id), class: 'glyphicon glyphicon-calendar' %></li>
+                <li><%= link_to '日記投稿', new_diary_path(current_user.id), class: 'glyphicon glyphicon-pencil' %></li>
                 <li><%= link_to 'My日記一覧', diaries_path(current_user.id), class: 'glyphicon glyphicon-book books' %></li>
                 <li><%= link_to 'みんなの日記', index_all_path(current_user.id), class: 'glyphicon glyphicon-book books' %></li>
-                <li><%= link_to '目標登録', new_goal_path(current_user.id), class: 'glyphicon glyphicon-user users' %></li>
-                <li><%= link_to '目標一覧', goals_path(current_user.id), class: 'glyphicon glyphicon-home home' %></li>
+                <li><%= link_to '目標登録', new_goal_path(current_user.id), class: 'glyphicon glyphicon-flag' %></li>
+                <li><%= link_to '目標一覧', goals_path(current_user.id), class: 'glyphicon glyphicon-flag' %></li>
                 <li><%= link_to 'ログアウト', destroy_user_session_path, method: :delete, class: 'glyphicon glyphicon-log-out logout' %></li>
               <% else %>
                 <li><%= link_to '新規登録', new_user_registration_path, class: 'glyphicon glyphicon-edit sign_up' %></li>

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,8 +10,6 @@ module GrowingUpDiary
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
-    config.i18n.default_locale = :ja
-    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s] #日本語環境に変更
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/locales/kaminari_ja.yml
+++ b/config/locales/kaminari_ja.yml
@@ -5,4 +5,4 @@ ja:
       last: "最後 &raquo;"
       previous: "&lsaquo; 前へ"
       next: "次へ &rsaquo;"
-      truncate: "..."
+      truncate: "..."        #ページングを日本語対応してしまうと、カレンダーが機能しなくなるため日本語化解除しています


### PR DESCRIPTION
・カレンダーの表示を変更。
・カレンダーに追加する予定の一覧と詳細ページに記載されていた、書く予定の開始と終了日時のUTC表記を削除。
・前回のページングの日本語変更による原因で、カレンダーと予定の管理機能が動かなくなってしまったので、問題解決のため削除。
